### PR TITLE
Create a tag on the Managed Instance holding the version of the upload agent

### DIFF
--- a/template/pyproject.toml.jinja
+++ b/template/pyproject.toml.jinja
@@ -33,7 +33,7 @@ dev = [
     "pytest>={% endraw %}{{ pytest_version }}{% raw %}",
     "pytest-cov>={% endraw %}{{ pytest_cov_version }}{% raw %}",
     "pytest-randomly>={% endraw %}{{ pytest_randomly_version }}{% raw %}",
-    "boto3-stubs[all]>={% endraw %}{{ boto3_version }}{% raw %}",
+    "boto3-stubs[all]=={% endraw %}{{ boto3_version }}{% raw %}", # there's a bug/conflict in 1.37.4 affecting pyright: https://github.com/LabAutomationAndScreening/copier-cloud-courier-infrastructure/actions/runs/13596390146/job/38014193360#step:11:69
 ]
 
 

--- a/template/src/cloud_courier_infrastructure/lib/hybrid_activation.py
+++ b/template/src/cloud_courier_infrastructure/lib/hybrid_activation.py
@@ -161,7 +161,7 @@ class OnPremNode(ComponentResource):
             opts=ResourceOptions(parent=role),
         )
         original_computer_info_tag_key = "original-computer-info"
-        installed_agent_version_tag_key = "installed-cloud-courier-agent-version"
+        installed_agent_version_tag_key = "installed-cloud-courier-agent-version"  # Warning! This tag key is used in the Cloud Courier Agent, so changing it will require changes there as well
         _ = RolePolicy(  # the native provider gave some odd CloudControl error about the policy, even though it has no Outputs in it
             append_resource_suffix(f"{resource_name}-update-instance-tag", max_length=100),
             role=role.role_name,  # type: ignore[reportArgumentType] # pyright somehow thinks that a role_name can be None...which cannot happen
@@ -185,6 +185,13 @@ class OnPremNode(ComponentResource):
                                 values=[installed_agent_version_tag_key],
                             ),
                         ],
+                    ),
+                    GetPolicyDocumentStatementArgs(
+                        sid="FindInstanceId",
+                        effect="Allow",
+                        actions=["ssm:DescribeInstanceInformation"],
+                        resources=["*"],
+                        # does not appear to be an easy way to lock this down further, although maybe tags might help. but seems generally low risk
                     ),
                 ]
             ).json,

--- a/template/src/cloud_courier_infrastructure/lib/hybrid_activation.py
+++ b/template/src/cloud_courier_infrastructure/lib/hybrid_activation.py
@@ -185,7 +185,9 @@ class OnPremNode(ComponentResource):
         )
         fixed_tags = common_tags()  # changes to the tags of the Activation will trigger replacement
         fixed_tags["original-computer-info"] = original_resource_name
-        fixed_tags["installed-cloud-courier-agent-version"] = ""
+        fixed_tags["installed-cloud-courier-agent-version"] = (
+            "uninstalled"  # leaving it blank doesn't let you use it as a filter for SSM Command targeting
+        )
         activation = Activation(
             immutable_resource_name,
             description=f"For the computer originally named: {original_resource_name}.",

--- a/template/src/cloud_courier_infrastructure/lib/program.py
+++ b/template/src/cloud_courier_infrastructure/lib/program.py
@@ -41,12 +41,13 @@ def pulumi_program() -> None:
         )
         all_node_alerts.append(NodeAlert(lab_computer_config=computer_config))
     _ = Dashboard(node_alerts=all_node_alerts)
+    cloud_courier_agent_version = "0.0.4"
     _ = CloudCourierAgentInstaller(
-        version="0.0.3",
+        version=cloud_courier_agent_version,
         files_to_package=[
             DistributorFileToPackage(
-                source_path="s3://manual-artifacts--artifact-stores--prod-82ba004/cloud-courier/v0.0.3/exe-windows-2022-3.12.7.zip",
-                local_name="exe-v0.0.3.zip",
+                source_path=f"s3://manual-artifacts--artifact-stores--prod-82ba004/cloud-courier/v{cloud_courier_agent_version}/exe-windows-2022-3.12.7.zip",
+                local_name=f"exe-v{cloud_courier_agent_version}.zip",
             )
         ],
         download_exe_from_github=DOWNLOAD_EXE_FROM_GITHUB,

--- a/template/src/cloud_courier_infrastructure/lib/ssm_distributor.py
+++ b/template/src/cloud_courier_infrastructure/lib/ssm_distributor.py
@@ -188,8 +188,8 @@ class CloudCourierAgentInstaller(ComponentResource):
             parent=self,
         )
         _ = ssm.Document(
-            append_resource_suffix(resource_name),
-            name=append_resource_suffix(resource_name),
+            append_resource_suffix(package_base_name),
+            name=append_resource_suffix(package_base_name),
             opts=ResourceOptions(
                 parent=self, depends_on=[upload_manifest_command.upload_command, upload_package_command.upload_command]
             ),

--- a/template/src/cloud_courier_infrastructure/lib/ssm_distributor.py
+++ b/template/src/cloud_courier_infrastructure/lib/ssm_distributor.py
@@ -270,7 +270,7 @@ class CloudCourierAgentInstaller(ComponentResource):
         )
 
     def _generate_uninstall_script(self) -> str:
-        return inspect.cleandoc(
+        return inspect.cleandoc(  # TODO: stop the exe before uninstalling it
             "".join(
                 [
                     rf"""

--- a/template/src/cloud_courier_infrastructure/lib/ssm_distributor.py
+++ b/template/src/cloud_courier_infrastructure/lib/ssm_distributor.py
@@ -4,7 +4,6 @@ import json
 import os
 from pathlib import Path
 from tempfile import gettempdir
-from typing import TYPE_CHECKING
 from urllib.parse import urlparse
 from zipfile import ZipFile
 
@@ -27,16 +26,10 @@ from .ssm_lib import LOGS_DIR
 from .ssm_lib import STOP_FLAG_DIR
 from .ssm_lib import add_boilerplate_to_ps_script
 
-if TYPE_CHECKING:
-    from mypy_boto3_s3 import S3Client
-    from mypy_boto3_ssm import SSMClient
-
 
 def get_central_infra_ssm_packages_bucket_name() -> str:
     org_home_region = get_config_str("proj:aws_org_home_region")
-    ssm_client: SSMClient = boto3.client(
-        "ssm", region_name=org_home_region
-    )  # not sure why pyright is getting angry without the explicit type hint
+    ssm_client = boto3.client("ssm", region_name=org_home_region)
     bucket_param = ssm_client.get_parameter(Name="/org-managed/ssm-distributor-packages-bucket-name")["Parameter"]
     assert "Value" in bucket_param, f"Expected 'Value' in {bucket_param}"
     return bucket_param["Value"]
@@ -108,9 +101,7 @@ class DistributorFileToPackage(BaseModel):
 
 def download_s3_file(*, file_to_package: DistributorFileToPackage, local_file_dir: Path, aws_region: str) -> Path:
     boto_session = boto3.Session()
-    s3_client: S3Client = boto_session.client(
-        "s3", region_name=aws_region
-    )  # not sure why pyright is getting angry without the explicit type hint
+    s3_client = boto_session.client("s3", region_name=aws_region)
     parsed_url = urlparse(
         file_to_package.source_path, allow_fragments=False
     )  # based on https://stackoverflow.com/questions/42641315/s3-urls-get-bucket-name-and-path

--- a/template/src/cloud_courier_infrastructure/lib/ssm_distributor.py
+++ b/template/src/cloud_courier_infrastructure/lib/ssm_distributor.py
@@ -4,6 +4,7 @@ import json
 import os
 from pathlib import Path
 from tempfile import gettempdir
+from typing import TYPE_CHECKING
 from urllib.parse import urlparse
 from zipfile import ZipFile
 
@@ -26,10 +27,16 @@ from .ssm_lib import LOGS_DIR
 from .ssm_lib import STOP_FLAG_DIR
 from .ssm_lib import add_boilerplate_to_ps_script
 
+if TYPE_CHECKING:
+    from mypy_boto3_s3 import S3Client
+    from mypy_boto3_ssm import SSMClient
+
 
 def get_central_infra_ssm_packages_bucket_name() -> str:
     org_home_region = get_config_str("proj:aws_org_home_region")
-    ssm_client = boto3.client("ssm", region_name=org_home_region)
+    ssm_client: SSMClient = boto3.client(
+        "ssm", region_name=org_home_region
+    )  # not sure why pyright is getting angry without the explicit type hint
     bucket_param = ssm_client.get_parameter(Name="/org-managed/ssm-distributor-packages-bucket-name")["Parameter"]
     assert "Value" in bucket_param, f"Expected 'Value' in {bucket_param}"
     return bucket_param["Value"]
@@ -101,7 +108,9 @@ class DistributorFileToPackage(BaseModel):
 
 def download_s3_file(*, file_to_package: DistributorFileToPackage, local_file_dir: Path, aws_region: str) -> Path:
     boto_session = boto3.Session()
-    s3_client = boto_session.client("s3", region_name=aws_region)
+    s3_client: S3Client = boto_session.client(
+        "s3", region_name=aws_region
+    )  # not sure why pyright is getting angry without the explicit type hint
     parsed_url = urlparse(
         file_to_package.source_path, allow_fragments=False
     )  # based on https://stackoverflow.com/questions/42641315/s3-urls-get-bucket-name-and-path

--- a/template/src/cloud_courier_infrastructure/lib/ssm_run_commands.py
+++ b/template/src/cloud_courier_infrastructure/lib/ssm_run_commands.py
@@ -116,7 +116,7 @@ class CloudCourierSsmCommands(ComponentResource):
                     "mainSteps": [
                         {
                             "action": "aws:runPowerShellScript",
-                            "name": "StartCloudCourier",
+                            "name": "StopCloudCourier",
                             "precondition": {"StringEquals": ["platformType", "Windows"]},
                             "inputs": {
                                 "timeoutSeconds": 600,


### PR DESCRIPTION
 ## Why is this change necessary?
To make it easier to install/update the agent across multiple instances simultaneously, there's not a tag on the instances indicating the current version of the cloud courier upload agent that's installed.  


 ## How does this change address the issue?
The tag is initialized to "N/A", and then the agent updates it when it boots up.


 ## What side effects does this change have?
The IAM Role for the instance is expanded to be able to describe instance information and update the tag on the instance.


 ## How is this change tested?
On my local computer with the new version of the agent.


 ## Other
Fixed a typo of Start->Stop. Removed the version from the AWS resource name of the Distributor Package

Only displays the activation code in the stack output if that instance hasn't yet been activated; this stops a huge buildup of outputs for many lab PCs.